### PR TITLE
brig term layout improvements

### DIFF
--- a/v2/cli/term/event_page.go
+++ b/v2/cli/term/event_page.go
@@ -40,7 +40,8 @@ func newEventPage(
 		),
 	}
 	e.eventInfo.SetBorder(true).SetBorderColor(tcell.ColorYellow)
-	e.workerInfo.SetBorder(true).SetBorderColor(tcell.ColorYellow)
+	e.workerInfo.SetBorder(true).SetBorderColor(tcell.ColorYellow).
+		SetTitle("Worker")
 	e.jobsTable.SetBorder(true).SetTitle("Jobs")
 	// Create the layout
 	e.page.Flex = tview.NewFlex().
@@ -69,9 +70,10 @@ func (e *eventPage) refresh(eventID string) {
 
 	// Set color of event and job boxes to match with current worker status
 	workerPhaseColor := getColorFromWorkerPhase(event.Worker.Status.Phase)
-	e.eventInfo.SetBorderColor(workerPhaseColor)
-	e.workerInfo.SetBorderColor(workerPhaseColor)
-	e.jobsTable.SetBorderColor(workerPhaseColor)
+	e.eventInfo.SetBorderColor(workerPhaseColor).
+		SetTitleColor(workerPhaseColor)
+	e.workerInfo.SetBorderColor(workerPhaseColor).
+		SetTitleColor(workerPhaseColor)
 
 	// Set key handlers
 	e.jobsTable.SetInputCapture(func(evt *tcell.EventKey) *tcell.EventKey {
@@ -102,7 +104,7 @@ func (e *eventPage) refresh(eventID string) {
 func (e *eventPage) fillEventInfo(event core.Event) {
 
 	e.eventInfo.Clear()
-	e.eventInfo.SetTitle(fmt.Sprintf("[yellow]Event: [white]%s\n", event.ID))
+	e.eventInfo.SetTitle(event.ID)
 	eventText := fmt.Sprintf(
 		"[yellow]Source: [white]%s\n"+
 			"[yellow]Type: [white]%s\n"+
@@ -127,9 +129,9 @@ func (e *eventPage) fillEventInfo(event core.Event) {
 	e.workerInfo.Clear()
 	e.workerInfo.SetText(
 		fmt.Sprintf(
-			"[yellow]Worker Phase: [white]%s\n"+
-				"[yellow]Worker Started: [white]%s\n"+
-				"[yellow]Worker Ended: [white]%s\n",
+			"[yellow]Phase: [white]%s\n"+
+				"[yellow]Started: [white]%s\n"+
+				"[yellow]Ended: [white]%s\n",
 			event.Worker.Status.Phase,
 			formatDateTimeToString(*event.Worker.Status.Started),
 			formatDateTimeToString(*event.Worker.Status.Ended),

--- a/v2/cli/term/event_page.go
+++ b/v2/cli/term/event_page.go
@@ -115,13 +115,19 @@ func (e *eventPage) fillEventInfo(event core.Event) {
 	)
 
 	// Add qualifiers (if any) to event info box
-	for k, v := range event.Qualifiers {
-		eventText = eventText + fmt.Sprintf("\n[yellow]%s: [white]%s", k, v)
+	if event.Qualifiers != nil {
+		eventText += "\n[yellow]Qualifiers:"
+		for k, v := range event.Qualifiers {
+			eventText += fmt.Sprintf("\n\t[yellow]%s: [white]%s", k, v)
+		}
 	}
 
 	// Add labels (if any) to event info box
-	for k, v := range event.Labels {
-		eventText = eventText + fmt.Sprintf("\n[yellow]%s: [white]%s", k, v)
+	if event.Labels != nil {
+		eventText += "\n[yellow]Labels:"
+		for k, v := range event.Labels {
+			eventText += fmt.Sprintf("\n\t[yellow]%s: [white]%s", k, v)
+		}
 	}
 
 	e.eventInfo.SetText(eventText)

--- a/v2/cli/term/event_page.go
+++ b/v2/cli/term/event_page.go
@@ -100,18 +100,29 @@ func (e *eventPage) refresh(eventID string) {
 }
 
 func (e *eventPage) fillEventInfo(event core.Event) {
+
 	e.eventInfo.Clear()
 	e.eventInfo.SetTitle(fmt.Sprintf("[yellow]Event: [white]%s\n", event.ID))
-	e.eventInfo.SetText(
-		fmt.Sprintf(
-			"[yellow]Source: [white]%s\n"+
-				"[yellow]Type: [white]%s\n"+
-				"[yellow]Time Created: [white]%s",
-			event.Source,
-			event.Type,
-			formatDateTimeToString(*event.Created),
-		),
+	eventText := fmt.Sprintf(
+		"[yellow]Source: [white]%s\n"+
+			"[yellow]Type: [white]%s\n"+
+			"[yellow]Time Created: [white]%s",
+		event.Source,
+		event.Type,
+		formatDateTimeToString(*event.Created),
 	)
+
+	// Add qualifiers (if any) to event info box
+	for k, v := range event.Qualifiers {
+		eventText = eventText + fmt.Sprintf("\n[yellow]%s: [white]%s", k, v)
+	}
+
+	// Add labels (if any) to event info box
+	for k, v := range event.Labels {
+		eventText = eventText + fmt.Sprintf("\n[yellow]%s: [white]%s", k, v)
+	}
+
+	e.eventInfo.SetText(eventText)
 
 	e.workerInfo.Clear()
 	e.workerInfo.SetText(

--- a/v2/cli/term/event_page.go
+++ b/v2/cli/term/event_page.go
@@ -94,13 +94,12 @@ func (e *eventPage) refresh(eventID string) {
 
 func (e *eventPage) fillEventInfo(event core.Event) {
 	e.eventInfo.Clear()
+	e.eventInfo.SetTitle(fmt.Sprintf("[yellow]Event: [white]%s\n", event.ID))
 	e.eventInfo.SetText(
 		fmt.Sprintf(
-			"[yellow]Event: [white]%s\n"+
-				"[yellow]Source: [white]%s\n"+
+			"[yellow]Source: [white]%s\n"+
 				"[yellow]Type: [white]%s\n"+
 				"[yellow]Time Created: [white]%s",
-			event.ID,
 			event.Source,
 			event.Type,
 			formatDateTimeToString(*event.Created),

--- a/v2/cli/term/event_page.go
+++ b/v2/cli/term/event_page.go
@@ -66,6 +66,13 @@ func (e *eventPage) refresh(eventID string) {
 	}
 	e.fillEventInfo(event)
 	e.fillJobsTable(event)
+
+	// Set color of event and job boxes to match with current worker status
+	workerPhaseColor := getColorFromWorkerPhase(event.Worker.Status.Phase)
+	e.eventInfo.SetBorderColor(workerPhaseColor)
+	e.workerInfo.SetBorderColor(workerPhaseColor)
+	e.jobsTable.SetBorderColor(workerPhaseColor)
+
 	// Set key handlers
 	e.jobsTable.SetInputCapture(func(evt *tcell.EventKey) *tcell.EventKey {
 		switch evt.Key() {

--- a/v2/cli/term/event_page.go
+++ b/v2/cli/term/event_page.go
@@ -127,14 +127,22 @@ func (e *eventPage) fillEventInfo(event core.Event) {
 	e.eventInfo.SetText(eventText)
 
 	e.workerInfo.Clear()
+	workerStartTime := ""
+	workerEndTime := ""
+	if event.Worker.Status.Started != nil {
+		workerStartTime = formatDateTimeToString(*event.Worker.Status.Started)
+		if event.Worker.Status.Ended != nil {
+			workerEndTime = formatDateTimeToString(*event.Worker.Status.Ended)
+		}
+	}
 	e.workerInfo.SetText(
 		fmt.Sprintf(
 			"[yellow]Phase: [white]%s\n"+
 				"[yellow]Started: [white]%s\n"+
 				"[yellow]Ended: [white]%s\n",
 			event.Worker.Status.Phase,
-			formatDateTimeToString(*event.Worker.Status.Started),
-			formatDateTimeToString(*event.Worker.Status.Ended),
+			workerStartTime,
+			workerEndTime,
 		),
 	)
 }

--- a/v2/cli/term/project_page.go
+++ b/v2/cli/term/project_page.go
@@ -121,7 +121,7 @@ func (p *projectPage) refresh(projectID string) {
 
 func (p *projectPage) fillProjectInfo(project core.Project) {
 	p.projectInfo.Clear()
-	p.projectInfo.SetTitle(fmt.Sprintf("[yellow]Project: [white]%s\n", project.ID))
+	p.projectInfo.SetTitle(fmt.Sprintf("[white]%s\n", project.ID))
 	p.projectInfo.SetText(
 		fmt.Sprintf(
 			"[yellow]Description: [white]%s\n"+

--- a/v2/cli/term/project_page.go
+++ b/v2/cli/term/project_page.go
@@ -121,12 +121,11 @@ func (p *projectPage) refresh(projectID string) {
 
 func (p *projectPage) fillProjectInfo(project core.Project) {
 	p.projectInfo.Clear()
+	p.projectInfo.SetTitle(fmt.Sprintf("[yellow]Project: [white]%s\n", project.ID))
 	p.projectInfo.SetText(
 		fmt.Sprintf(
-			"[yellow]Project: [white]%s\n"+
-				"[yellow]Description: [white]%s\n"+
+			"[yellow]Description: [white]%s\n"+
 				"[yellow]Time Created: [white]%s",
-			project.ID,
 			project.Description,
 			formatDateTimeToString(*project.Created),
 		),


### PR DESCRIPTION
This PR contains a series of layout improvements for `brig term`

1. Move project name to be title of project box
2. Move event id to be title of event box
3. Make border color of event and job detail text boxes dependent on worker status on event page
4. Add event qualifiers and labels to the event info text box
