### PR TITLE
Replace job log box with container table

### DIFF
--- a/v2/cli/term/job_page.go
+++ b/v2/cli/term/job_page.go
@@ -57,7 +57,7 @@ func (j *jobPage) refresh(eventID, jobName string) {
 		// TODO: Handle this
 	}
 	j.fillJobInfo(eventID, job)
-	j.fillContainerTable(eventID, job)
+	j.fillContainersTable(eventID, job)
 	// Set key handlers
 	j.containersTable.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		switch event.Key() {
@@ -107,7 +107,7 @@ func (j *jobPage) fillJobInfo(eventID string, job core.Job) {
 	j.jobInfo.SetText(infoText)
 }
 
-func (j *jobPage) fillContainerTable(eventID string, job core.Job) {
+func (j *jobPage) fillContainersTable(eventID string, job core.Job) {
 	const (
 		statusCol int = iota
 		nameCol
@@ -178,7 +178,7 @@ func (j *jobPage) fillContainerTable(eventID string, job core.Job) {
 			&tview.TableCell{
 				Text:  k,
 				Align: tview.AlignLeft,
-				Color: color,
+				Color: tcell.ColorWhite,
 			},
 		).SetCell(
 			row,
@@ -186,7 +186,7 @@ func (j *jobPage) fillContainerTable(eventID string, job core.Job) {
 			&tview.TableCell{
 				Text:  v.Image,
 				Align: tview.AlignLeft,
-				Color: color,
+				Color: tcell.ColorWhite,
 			},
 		)
 	}

--- a/v2/cli/term/job_page.go
+++ b/v2/cli/term/job_page.go
@@ -111,6 +111,7 @@ func (j *jobPage) fillContainerTable(eventID string, job core.Job) {
 	const (
 		statusCol int = iota
 		nameCol
+		imageCol
 	)
 
 	j.containersTable.Clear()
@@ -126,6 +127,14 @@ func (j *jobPage) fillContainerTable(eventID string, job core.Job) {
 		nameCol,
 		&tview.TableCell{
 			Text:  "Name",
+			Align: tview.AlignCenter,
+			Color: tcell.ColorYellow,
+		},
+	).SetCell(
+		0,
+		imageCol,
+		&tview.TableCell{
+			Text:  "Image",
 			Align: tview.AlignCenter,
 			Color: tcell.ColorYellow,
 		},
@@ -147,9 +156,38 @@ func (j *jobPage) fillContainerTable(eventID string, job core.Job) {
 		row,
 		nameCol,
 		&tview.TableCell{
+			Text:  job.Name,
+			Align: tview.AlignLeft,
+			Color: color,
+		},
+	).SetCell(
+		row,
+		imageCol,
+		&tview.TableCell{
 			Text:  job.Spec.PrimaryContainer.ContainerSpec.Image,
 			Align: tview.AlignLeft,
 			Color: color,
 		},
 	)
+
+	for k, v := range job.Spec.SidecarContainers {
+		row++
+		j.containersTable.SetCell(
+			row,
+			nameCol,
+			&tview.TableCell{
+				Text:  k,
+				Align: tview.AlignLeft,
+				Color: color,
+			},
+		).SetCell(
+			row,
+			imageCol,
+			&tview.TableCell{
+				Text:  v.Image,
+				Align: tview.AlignLeft,
+				Color: color,
+			},
+		)
+	}
 }


### PR DESCRIPTION
This PR replaces the log box on the job detail page with a table listing all of the job containers
