### PR TITLE
Fix seg fault when starting brig term while events haven't started yet

### DIFF
--- a/v2/cli/term/projects_page.go
+++ b/v2/cli/term/projects_page.go
@@ -175,7 +175,11 @@ func (p *projectsPage) fillProjectsTable(
 		if found {
 			color = getColorFromWorkerPhase(lastEvent.Worker.Status.Phase)
 			icon = getIconFromWorkerPhase(lastEvent.Worker.Status.Phase)
-			since = time.Since(*lastEvent.Worker.Status.Started).Truncate(time.Second)
+			if lastEvent.Worker.Status.Started != nil {
+				since = time.Since(
+					*lastEvent.Worker.Status.Started,
+				).Truncate(time.Second)
+			}
 		}
 		p.projectsTable.SetCell(
 			row,


### PR DESCRIPTION
Fixes a bug with setting the `since` variable in `projects_page`, where the worker start time is not guaranteed to be not nil.
